### PR TITLE
Node を 22.22.0 にアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.18.0-slim
+FROM node:22.22.0
 
 RUN apt-get update && apt-get install -y \
   git \


### PR DESCRIPTION
fix https://github.com/progedu/intro-2024-edition/issues/1628
1月13日にセキュリティパッチの v22.22.0 がリリースされたので更新しました。

improve-dockerfile からブランチを切っております。